### PR TITLE
fix(client/order): Fix an error with international addresses

### DIFF
--- a/lib/client/order.rb
+++ b/lib/client/order.rb
@@ -152,7 +152,9 @@ module BigcommerceOrderAgent
         country = Country.named(address['country'])
         state = country.subregions.named(address['state'])
 
-        return state.code
+        #  For cases where a matching state is not found, default to the `state`
+        #  value on the address. (This is not uncommon for international addresses)
+        return state.nil? ? address['state'] : state.code
       end
     end
   end


### PR DESCRIPTION
Address an error in the order lookup that causes tasks to fail when working with intrnational
addresses

https://trello.com/c/qAXSNgNy/668-asbat-see-all-orders-sent-to-acumen